### PR TITLE
Fix Clear Cart Button

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,8 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatButtonModule} from '@angular/material/button';
 import { CartModule } from './cart/cart.module';
+import { MatListModule } from '@angular/material/list';
+
 
 @NgModule({
   declarations: [
@@ -20,7 +22,8 @@ import { CartModule } from './cart/cart.module';
     ProductModule,
     MatToolbarModule,
     MatButtonModule,
-    CartModule
+    CartModule,
+    MatListModule
   ],
   providers: [
     provideAnimationsAsync()

--- a/src/app/cart/cart-view/cart-view.component.html
+++ b/src/app/cart/cart-view/cart-view.component.html
@@ -15,7 +15,17 @@
                 <span class="price" matListItemLine>{{totalPrice | currency:"MYR "}}</span>
             </mat-list-item>
 
-        <mat-card-actions>
+            <mat-card-actions>
+              <mat-list-item class="text-right">
+                <button mat-flat-button (click)="clearCart()">Clear</button>
+             </mat-list-item>
+            </mat-card-actions>
+
+          <mat-list-item class="text-right">
+            <button mat-flat-button (click)="testMethod()">Checkout</button>
+         </mat-list-item>
+
+      <mat-card-actions>
           <button mat-raised-button (click)="clearCart()">Clear</button>
           <mat-list-item>
         <button mat-raised-button color="accent">CheckOut</button>

--- a/src/app/cart/cart-view/cart-view.component.html
+++ b/src/app/cart/cart-view/cart-view.component.html
@@ -10,13 +10,18 @@
             </mat-list-item>
         </mat-list>
 
-
-        <mat-list>
             <mat-list-item>
                 <span class="price" matListItemTitle>Total MYR</span>
                 <span class="price" matListItemLine>{{totalPrice | currency:"MYR "}}</span>
             </mat-list-item>
-        </mat-list>
+
+        <mat-card-actions>
+          <button mat-raised-button (click)="clearCart()">Clear</button>
+          <mat-list-item>
+        <button mat-raised-button color="accent">CheckOut</button>
+          </mat-list-item>
+      </mat-card-actions>
+
 
     </mat-card>
 

--- a/src/app/cart/cart-view/cart-view.component.ts
+++ b/src/app/cart/cart-view/cart-view.component.ts
@@ -15,7 +15,7 @@ export class CartViewComponent implements OnInit {
 
   constructor(private cartService: CartService) {}
 
-  ngOnInit(): void {  
+  ngOnInit(): void {
       this.cartService.getCartItems().subscribe(data => {
 
         this.cartItems = data;
@@ -31,6 +31,17 @@ export class CartViewComponent implements OnInit {
     }
     return total;
   }
+
+  //problem function:
+  clearCart(): void {
+    this.cartService.clearCart().subscribe();
+  }
+
+  //test:
+  testMethod(): void {
+    console.log('Test method called');
+  }
+
 
 
 }

--- a/src/app/cart/cart.module.ts
+++ b/src/app/cart/cart.module.ts
@@ -16,7 +16,7 @@ import { MatButtonModule } from '@angular/material/button';
     MatCardModule,
     MatListModule,
     FlexModule,
-    MatButtonModule
+    MatButtonModule,
   ]
 })
 export class CartModule { }

--- a/src/app/cart/cart.service.ts
+++ b/src/app/cart/cart.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { environment } from '../../environments/environment';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
 import { Product } from '../models/product';
+import { catchError } from 'rxjs/operators';
 
 
 @Injectable({


### PR DESCRIPTION
The issue of bug on material angular:

Cannot function:
```
           <mat-list-item class="text-right">
                <button mat-flat-button (click)="clearCart()">Clear</button>
             </mat-list-item>

          <mat-list-item class="text-right">
            <button mat-flat-button (click)="testMethod()">Checkout</button>
         </mat-list-item>
```

Can function:
```
      <mat-card-actions>
          <button mat-raised-button (click)="clearCart()">Clear</button>
          <mat-list-item>
        <button mat-raised-button color="accent">CheckOut</button>
          </mat-list-item>
      </mat-card-actions>
```

Need investigate more



